### PR TITLE
Multipath fixes for RHOSP13 and RHOSP16.1

### DIFF
--- a/RHOSP13/cinder-pure-config.yaml
+++ b/RHOSP13/cinder-pure-config.yaml
@@ -14,3 +14,7 @@ parameter_defaults:
   CinderPureUseChap: false
   CinderPureMultipathXfer: true
   CinderPureImageCache: true
+  NovaLibvirtVolumeUseMultipath:  true
+  NovaComputeOptVolumes:
+    - /etc/multipath.conf:/etc/multipath.conf:ro
+    - /etc/multipath/:/etc/multipath/:rw

--- a/RHOSP13/pure-temp.yaml
+++ b/RHOSP13/pure-temp.yaml
@@ -14,6 +14,7 @@ resources:
         config: |
           #!/bin/bash
           sudo mpathconf --enable
+          sed -i "s/^defaults {/defaults {\n\tskip_kpartx yes/" /etc/multipath.conf
           sudo systemctl start multipathd 
           sudo systemctl enable multipathd 
           cat <<EOF >>/tmp/99-pure-storage.rules

--- a/RHOSP16.1/cinder-pure-config.yaml
+++ b/RHOSP16.1/cinder-pure-config.yaml
@@ -15,3 +15,7 @@ parameter_defaults:
   CinderPureMultipathXfer: true
   CinderPureImageCache: true
   CinderPureMultiConfig: {}
+  NovaLibvirtVolumeUseMultipath:  true
+  NovaComputeOptVolumes:
+    - /etc/multipath.conf:/etc/multipath.conf:ro
+    - /etc/multipath/:/etc/multipath/:rw

--- a/RHOSP16.1/pure-temp.yaml
+++ b/RHOSP16.1/pure-temp.yaml
@@ -23,6 +23,7 @@ resources:
           cat <<EOF >>/tmp/multipath.conf
           defaults {
             polling_interval      10
+            skip_kpartx yes
           }
           devices {
             device {


### PR DESCRIPTION
Additional Multipath Settings as recommended by Red Hat

- https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html-single/storage_guide/index#configure-multipath-on-new-deployments

- https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html-single/storage_guide/index#configure-multipath-on-new-deployments